### PR TITLE
Game blocks

### DIFF
--- a/block-fabric/src/blocks/fabric_blocks.js
+++ b/block-fabric/src/blocks/fabric_blocks.js
@@ -26,3 +26,11 @@ Blockly.defineBlocksWithJsonArray([
   },
 ]);
 
+/**
+ * Defines the JavaScript generation for place_holder_fabric_block.
+ * @type {!Function}
+ */
+Blockly.JavaScript['place_holder_fabric_block'] = () => {
+  return ['fabric block', Blockly.JavaScript.ORDER_ATOMIC];
+};
+

--- a/block-fabric/src/blocks/fabric_blocks.js
+++ b/block-fabric/src/blocks/fabric_blocks.js
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Fabric blocks.
+ */
+
+import Blockly from 'blockly/core';
+
+/**
+ * The return type for a fabric shape block.
+ * @type {string}
+ */
+export const FABRIC_SHAPE_TYPE = 'FabricShape';  // TBD, may change
+
+
+Blockly.defineBlocksWithJsonArray([
+  {
+    'type': 'place_holder_fabric_block',
+    'message0': 'FabricShape',
+    'output': FABRIC_SHAPE_TYPE,
+    'colour': '#aaaaaa',
+  },
+]);
+

--- a/block-fabric/src/blocks/trivia.js
+++ b/block-fabric/src/blocks/trivia.js
@@ -18,8 +18,8 @@ import {FABRIC_SHAPE_TYPE} from './fabric_blocks';
 const TRIVIA_FUNCTION_HUE = 360;
 
 /**
- * Initializes an "event function" block given the name and arguments for the
- * block.
+ * Initializes an "event function" block with return given the name and
+ * arguments for the block.
  * @param {string} name The name of the function.
  * @param {string} args A comma separated string of the argument variable names.
  * @param {string} returnType The return type of the function.
@@ -27,7 +27,7 @@ const TRIVIA_FUNCTION_HUE = 360;
  * @this {Blockly.Block}
  * @private
  */
-const drawShapeEventInitFactory__ =
+const eventWithReturnInitFactory_ =
     function(name, args, returnType) {
   return function() {
     this.jsonInit({
@@ -56,21 +56,87 @@ const drawShapeEventInitFactory__ =
 };
 
 /**
- * Generates the JavaScript for a draw event function block.
+ * Initializes an "event function" block without return given the name and
+ * arguments for the block.
  * @param {string} name The name of the function.
  * @param {string} args A comma separated string of the argument variable names.
+ * @param {string} returnType The return type of the function.
+ * @return {!Function} An initialization function with arguments bound.
+ * @this {Blockly.Block}
+ * @private
+ */
+const eventNoReturnInitFactory_ = function(name, args) {
+  return function() {
+    this.jsonInit({
+      "message0": "%1 (%2) %3 %4",
+      "args0": [
+        name,
+        args,
+        {
+          "type": "input_dummy"
+        },
+        {
+          "type": "input_statement",
+          "name": "STACK"
+        }
+      ],
+      "inputsInline": true,
+      "colour": TRIVIA_FUNCTION_HUE,
+    });
+  };
+};
+
+const eventFuncBlockFactory_ = (name, args, returnType = undefined) => {
+  const argList = args.split(',');
+  return {
+    init: returnType ?
+        eventWithReturnInitFactory_(name, args, returnType) :
+        eventNoReturnInitFactory_(name, args),
+    getVars: () => argList,
+    customContextMenu: function (options) {
+      // Add options to create getters for arg parameter.
+      if (!this.isCollapsed()) {
+        argList.forEach((argName) => {
+          var option = {enabled: true};
+          var name = argName;
+          option.text = Blockly.Msg['VARIABLES_SET_CREATE_GET'].replace('%1',
+              name);
+          var xmlBlock = Blockly.utils.xml.createElement('block');
+          xmlBlock.setAttribute('type', 'variables_get');
+          var xmlField = Blockly.utils.xml.createElement('field');
+          xmlField.setAttribute('name', 'VAR');
+          var argumentName = Blockly.utils.xml.createTextNode(name);
+          xmlField.appendChild(argumentName);
+          xmlBlock.appendChild(xmlField);
+
+          option.callback = Blockly.ContextMenu.callbackFactory(this, xmlBlock);
+          options.push(option);
+        });
+      }
+    }
+  };
+};
+
+/**
+ * Generates the JavaScript for event function block with return.
+ * @param {string} name The name of the function.
+ * @param {string} args A comma separated string of the argument variable names.
+ * @param {boolean} hasReturn Whether there is a return value.
  * @return {!Function} A generator function with arguments bound.
  * @private
  */
-const drawShapeEventJavascriptFactory_ = (name, args) => {
+const eventFuncJavascriptFactory_ = (name, args, hasReturn) => {
   return function(block) {
-    // Define a procedure with a return value.
+    // Define a procedure with/without a return value.
     var branch = Blockly.JavaScript.statementToCode(block, 'STACK');
-    var returnValue = Blockly.JavaScript.valueToCode(block, 'RETURN',
-        Blockly.JavaScript.ORDER_NONE) || '';
-    returnValue = '  return ' + returnValue + ';\n';
-    var code = 'function ' + name + '(' + args + ') {\n' +
-        branch + returnValue + '}';
+    if (hasReturn) {
+      var returnValue = Blockly.JavaScript.valueToCode(block, 'RETURN',
+          Blockly.JavaScript.ORDER_NONE) || '';
+      returnValue = '  return ' + returnValue + ';\n';
+      branch += returnValue;
+
+    }
+    var code = 'function ' + name + '(' + args + ') {\n' + branch + '}';
     code = Blockly.JavaScript.scrub_(block, code);
     Blockly.JavaScript.definitions_[name] = code;
     return null;
@@ -81,28 +147,54 @@ const drawShapeEventJavascriptFactory_ = (name, args) => {
  * Block for drawQuestionShape shape event handler.
  * @type {{init: !Function}}
  */
-Blockly.Blocks['trivia_draw_question_shape'] = {
-  init: drawShapeEventInitFactory__('drawQuestionShape', 'question', FABRIC_SHAPE_TYPE)
-};
+Blockly.Blocks['trivia_draw_question_shape'] =
+    eventFuncBlockFactory_('drawQuestionShape', 'question', FABRIC_SHAPE_TYPE);
 
 /**
  * Defines the JavaScript generation for drawQuestionShape.
  * @type {!Function}
  */
 Blockly.JavaScript['trivia_draw_question_shape'] =
-    drawShapeEventJavascriptFactory_('drawQuestionShape', 'question');
+    eventFuncJavascriptFactory_('drawQuestionShape', 'question', true);
 
 /**
  * Block for defining drawAnswerShape event handler.
  * @type {{init: !Function}}
  */
-Blockly.Blocks['trivia_draw_answer_shape'] = {
-  init: drawShapeEventInitFactory__('drawAnswerShape', 'answer', FABRIC_SHAPE_TYPE)
-};
+Blockly.Blocks['trivia_draw_answer_shape'] =
+    eventFuncBlockFactory_('drawAnswerShape', 'answer', FABRIC_SHAPE_TYPE);
 
 /**
  * Defines the JavaScript generation for drawAnswerShape.
  * @type {!Function}
  */
 Blockly.JavaScript['trivia_draw_answer_shape'] =
-    drawShapeEventJavascriptFactory_('drawAnswerShape', 'answer');
+    eventFuncJavascriptFactory_('drawAnswerShape', 'answer', true);
+
+/**
+ * Block for defining onAnswerRight event handler.
+ * @type {{init: !Function}}
+ */
+Blockly.Blocks['trivia_on_answer_right'] =
+    eventFuncBlockFactory_('onAnswerRight', 'team, answer',);
+
+/**
+ * Defines the JavaScript generation for onAnswerRight.
+ * @type {!Function}
+ */
+Blockly.JavaScript['trivia_on_answer_right'] =
+    eventFuncJavascriptFactory_('onAnswerRight', 'team, answer', false);
+
+/**
+ * Block for defining onAnswerWrong event handler.
+ * @type {{init: !Function}}
+ */
+Blockly.Blocks['trivia_on_answer_wrong'] =
+    eventFuncBlockFactory_('onAnswerWrong', 'team, answer',);
+
+/**
+ * Defines the JavaScript generation for onAnswerWrong.
+ * @type {!Function}
+ */
+Blockly.JavaScript['trivia_on_answer_wrong'] =
+    eventFuncJavascriptFactory_('onAnswerWrong', 'team, answer', false);

--- a/block-fabric/src/blocks/trivia.js
+++ b/block-fabric/src/blocks/trivia.js
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Game blocks for trivia game.
+ */
+
+
+import Blockly from 'blockly/core';
+
+/**
+ * HSV hue for all trivia game blocks with function.
+ */
+const TRIVIA_FUNCTION_HUE = 360;
+
+/**
+ * The return type for a fabric shape block.
+ * @type {string}
+ */
+const FABRIC_SHAPE_TYPE = 'FabricShape';  // TBD, may change
+
+/**
+ * Initializes an "event function" block given the name and arguments for the
+ * block.
+ * @param {string} name The name of the function.
+ * @param {string} args A comma separated string of the argument variable names.
+ * @param {string} returnType The return type of the function.
+ * @return {!Function} An initialization function with arguments bound.
+ * @this {Blockly.Block}
+ * @private
+ */
+const drawShapeEventInitFactory__ =
+    function(name, args, returnType) {
+  return function() {
+    this.jsonInit({
+      "message0": "function %1(%2) { %3 %4 return %5 }",
+      "args0": [
+        name,
+        args,
+        {
+          "type": "input_dummy"
+        },
+        {
+          "type": "input_statement",
+          "name": "STACK"
+        },
+        {
+          "type": "input_value",
+          "check": returnType,
+          "align": "right",
+          "name": "RETURN"
+        }
+      ],
+      "inputsInline": true,
+      "colour": TRIVIA_FUNCTION_HUE,
+    });
+  };
+};
+
+/**
+ * Generates the JavaScript for a draw event function block.
+ * @param {string} name The name of the function.
+ * @param {string} args A comma separated string of the argument variable names.
+ * @return {!Function} A generator function with arguments bound.
+ * @private
+ */
+const drawShapeEventJavascriptFactory_ = (name, args) => {
+  return function(block) {
+    // Define a procedure with a return value.
+    var branch = Blockly.JavaScript.statementToCode(block, 'STACK');
+    var returnValue = Blockly.JavaScript.valueToCode(block, 'RETURN',
+        Blockly.JavaScript.ORDER_NONE) || '';
+    returnValue = '  return ' + returnValue + ';\n';
+    var code = 'function ' + name + '(' + args + ') {\n' +
+        branch + returnValue + '}';
+    code = Blockly.JavaScript.scrub_(block, code);
+    Blockly.JavaScript.definitions_[name] = code;
+    return null;
+  };
+};
+
+/**
+ * Block for drawQuestionShape shape event handler.
+ * @type {{init: !Function}}
+ */
+Blockly.Blocks['trivia_draw_question_shape'] = {
+  init: drawShapeEventInitFactory__('drawQuestionShape', 'question', FABRIC_SHAPE_TYPE)
+};
+
+/**
+ * Defines the JavaScript generation for drawQuestionShape.
+ * @type {!Function}
+ */
+Blockly.JavaScript['trivia_draw_question_shape'] =
+    drawShapeEventJavascriptFactory_('drawQuestionShape', 'question');
+
+/**
+ * Block for defining drawAnswerShape event handler.
+ * @type {{init: !Function}}
+ */
+Blockly.Blocks['trivia_draw_answer_shape'] = {
+  init: drawShapeEventInitFactory__('drawAnswerShape', 'answer', FABRIC_SHAPE_TYPE)
+};
+
+/**
+ * Defines the JavaScript generation for drawAnswerShape.
+ * @type {!Function}
+ */
+Blockly.JavaScript['trivia_draw_answer_shape'] =
+    drawShapeEventJavascriptFactory_('drawAnswerShape', 'answer');

--- a/block-fabric/src/blocks/trivia.js
+++ b/block-fabric/src/blocks/trivia.js
@@ -10,17 +10,12 @@
 
 
 import Blockly from 'blockly/core';
+import {FABRIC_SHAPE_TYPE} from './fabric_blocks';
 
 /**
  * HSV hue for all trivia game blocks with function.
  */
 const TRIVIA_FUNCTION_HUE = 360;
-
-/**
- * The return type for a fabric shape block.
- * @type {string}
- */
-const FABRIC_SHAPE_TYPE = 'FabricShape';  // TBD, may change
 
 /**
  * Initializes an "event function" block given the name and arguments for the
@@ -36,7 +31,7 @@ const drawShapeEventInitFactory__ =
     function(name, args, returnType) {
   return function() {
     this.jsonInit({
-      "message0": "function %1(%2) { %3 %4 return %5 }",
+      "message0": "%1 (%2) %3 %4 return %5",
       "args0": [
         name,
         args,

--- a/block-fabric/src/index.js
+++ b/block-fabric/src/index.js
@@ -29,3 +29,11 @@ Blockly.defineBlocksWithJsonArray([
     'colour': '#aaaaaa',
   },
 ]);
+
+/**
+ * Defines the JavaScript generation for place_holder_not_fabric_block.
+ * @type {!Function}
+ */
+Blockly.JavaScript['place_holder_not_fabric_block'] = () => {
+  return ['nor fabric block', Blockly.JavaScript.ORDER_ATOMIC];
+};

--- a/block-fabric/src/index.js
+++ b/block-fabric/src/index.js
@@ -9,7 +9,11 @@
  * @fileoverview Block overview.
  */
 
+import './blocks/trivia.js';
+import './blocks/fabric_blocks.js';
+
 import Blockly from 'blockly/core';
+import {FABRIC_SHAPE_TYPE} from './blocks/fabric_blocks';
 
 // TODO: Update block definition.
 Blockly.defineBlocksWithJsonArray([
@@ -17,5 +21,11 @@ Blockly.defineBlocksWithJsonArray([
     'type': 'block_template',
     'message0': 'block template',
     'style': 'math_blocks',
+  },
+  {
+    'type': 'place_holder_not_fabric_block',
+    'message0': 'Not a FabricShape',
+    'output': 'not' + FABRIC_SHAPE_TYPE,
+    'colour': '#aaaaaa',
   },
 ]);

--- a/block-fabric/test/index.js
+++ b/block-fabric/test/index.js
@@ -15,7 +15,9 @@ import '../src/index';
 
 // TODO: Edit list of blocks.
 const allBlocks = ['block_template', 'trivia_draw_question_shape',
-  'trivia_draw_answer_shape', 'place_holder_fabric_block', 'place_holder_not_fabric_block'];
+  'trivia_draw_answer_shape', 'place_holder_fabric_block',
+  'place_holder_not_fabric_block', 'trivia_on_answer_right',
+  'trivia_on_answer_wrong'];
 
 /**
  * Create a workspace.

--- a/block-fabric/test/index.js
+++ b/block-fabric/test/index.js
@@ -14,7 +14,8 @@ import '../src/index';
 
 
 // TODO: Edit list of blocks.
-const allBlocks = ['block_template'];
+const allBlocks = ['block_template', 'trivia_draw_question_shape',
+  'trivia_draw_answer_shape', 'place_holder_fabric_block', 'place_holder_not_fabric_block'];
 
 /**
  * Create a workspace.


### PR DESCRIPTION
### Summary
Adds blocks that allow user to implement logic for certain game events.
- `trivia_draw_question_shape` -> allows for defining what shape to use for draw question
- `trivia_draw_answer_shape`-> allows for defining what shape to use for draw answer
- `trivia_on_answer_right` -> should allow for adding custom logic for updating points 
- `trivia_on_answer_wrong`-> should allow for adding custom logic for updating points 

Also adds some placeholder blocks used for type checking:
- `place_holder_fabric_block`
- `place_holder_not_fabric_block`

### Screenshots
![image](https://user-images.githubusercontent.com/6621618/91903941-ec107480-ec58-11ea-9c39-1bdd75ac277c.png)

### Additional Information
Maybe in future to add logic for returning custom picture/animation for answer right/wrong (currently those blocks do not have return