### PR TITLE
If there is a block configuring the answer text, use it

### DIFF
--- a/block-fabric/src/blocks/fabric_blocks.js
+++ b/block-fabric/src/blocks/fabric_blocks.js
@@ -24,6 +24,33 @@ Blockly.defineBlocksWithJsonArray([
     'output': FABRIC_SHAPE_TYPE,
     'colour': '#aaaaaa',
   },
+  {
+    "type": "fabric_text",
+    "message0": "display text %1 with color %2",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "TEXT",
+        "check": "String"
+      },
+      {
+        "type": "input_value",
+        "name": "COLOUR"
+      }
+    ],
+    "output": FABRIC_SHAPE_TYPE,
+    "colour": 285,
+    "tooltip": "Create a Fabric text block",
+    "helpUrl": ""
+  },
+  {
+    "type": "answer_text_var",
+    "message0": "current answer text",
+    "output": "String",
+    "colour": 105,
+    "tooltip": "",
+    "helpUrl": ""
+  }
 ]);
 
 /**
@@ -32,5 +59,23 @@ Blockly.defineBlocksWithJsonArray([
  */
 Blockly.JavaScript['place_holder_fabric_block'] = () => {
   return ['fabric block', Blockly.JavaScript.ORDER_ATOMIC];
+};
+
+Blockly.JavaScript['fabric_text'] = function(block) {
+  var value_text = Blockly.JavaScript.valueToCode(block, 'TEXT', Blockly.JavaScript.ORDER_ATOMIC);
+  var value_colour = Blockly.JavaScript.valueToCode(block, 'COLOUR', Blockly.JavaScript.ORDER_ATOMIC);
+  // TODO: Assemble JavaScript into code variable.
+
+  var code = `var text = new fabric.Text(${value_text}, { left: 100, top: top, fill: ${value_colour}, fontSize: 20 });
+      this.canvas.add(text);`;
+  // TODO: Change ORDER_NONE to the correct strength.
+  return [code, Blockly.JavaScript.ORDER_NONE];
+};
+
+Blockly.JavaScript['answer_text_var'] = function(block) {
+  // TODO: Assemble JavaScript into code variable.
+  var code = 'optionText';
+  // TODO: Change ORDER_NONE to the correct strength.
+  return [code, Blockly.JavaScript.ORDER_NONE];
 };
 

--- a/block-fabric/src/gameUi.js
+++ b/block-fabric/src/gameUi.js
@@ -1,4 +1,5 @@
 import { fabric } from 'fabric';
+import * as Blockly from 'blockly';
 
 export class GameUi {
   constructor(id, onClickFn) {
@@ -82,7 +83,33 @@ export class GameUi {
 
   renderAnswerOptionText(index, optionText) {
     const top = 175 + (index * 75) + 5;
-    const text = new fabric.Text(optionText, { left: 100, top: top });
-    this.canvas.add(text);
+    var code = this.getCodeForBlockType('fabric_text');
+    if (code) {
+      eval(code);
+    } else {
+      const text = new fabric.Text(optionText, { left: 100, top: top });
+      this.canvas.add(text);
+    }
+    
+  }
+
+  /**
+   * Searches workspace for first block of given type and returns the code for it
+   * @param {string} type 
+   * @return {?string} code string, or null if block not found
+   */
+  getCodeForBlockType(type) {
+    const ws = Blockly.getMainWorkspace();
+    const block = ws.getTopBlocks(true).find(block => block.type === type);
+    if (!block) {
+      return null;
+    }
+    Blockly.JavaScript.init(ws);
+    let code = Blockly.JavaScript.blockToCode(block);
+    if (Array.isArray(code)) {
+      // Some blocks are a tuple of something, I don't know or care what the second thing is
+      return code[0];
+    }
+    return code;
   }
 }

--- a/block-fabric/test/index.html
+++ b/block-fabric/test/index.html
@@ -9,7 +9,8 @@
       margin: 0;
     }
     #editor {
-      height: 1500px;
+      height: 100vh;
+      max-height: 1500px;
       width: 100%;
       max-width: 1000px;
     }

--- a/block-fabric/test/index.js
+++ b/block-fabric/test/index.js
@@ -20,7 +20,8 @@ const allBlocks = [
   'block_template', 'trivia_draw_question_shape',
   'trivia_draw_answer_shape', 'place_holder_fabric_block',
   'place_holder_not_fabric_block', 'trivia_on_answer_right',
-  'trivia_on_answer_wrong', 'get_score', 'update_score', 'math_number'];
+  'trivia_on_answer_wrong', 'get_score', 'update_score', 'math_number',
+  'fabric_text', 'answer_text_var', 'text', 'colour_picker'];
 
 let gameController;
 let workspace;


### PR DESCRIPTION
Adds a new block type. when rendering answer text, it looks for that block. If it's there, it uses the block code, otherwise uses what it had before.

Have not yet figured out what to do with the order precedence things so ¯\_(ツ)_/¯

Also sets the height to 100vh because the scrolling was annoying me (my window is not 1500 px tall)